### PR TITLE
fix: set NODE_ENV

### DIFF
--- a/config.server.ts
+++ b/config.server.ts
@@ -91,6 +91,7 @@ export const createServerConfig = (
       }),
       new webpack.EnvironmentPlugin({
         REMIX_DEV_SERVER_WS_PORT: JSON.stringify(remixConfig.devServerPort),
+        NODE_ENV: JSON.stringify(mode),
       }),
       new webpack.ProvidePlugin({ React: ["react"] }),
     ],


### PR DESCRIPTION
closes #2 - otherwise it defaults to production

verified with some logs
<img width="682" alt="image" src="https://user-images.githubusercontent.com/11698668/200881411-89ae8f84-7bae-4cf8-9d0f-91ddd40d8a3d.png">


Signed-off-by: Logan McAnsh <logan@mcan.sh>