### PR TITLE
Add mode to the webpack config

### DIFF
--- a/config.browser.ts
+++ b/config.browser.ts
@@ -30,6 +30,7 @@ export const createBrowserConfig = (
 ): webpack.Configuration => {
   const browserRoutes = getBrowserRoutes(remixConfig);
   return {
+    mode,
     devtool: mode === "development" ? "inline-cheap-source-map" : undefined,
     target: "web",
     resolve: {

--- a/config.server.ts
+++ b/config.server.ts
@@ -15,6 +15,7 @@ export const createServerConfig = (
 
   const isModule = remixConfig.serverModuleFormat === "esm";
   return {
+    mode,
     devtool: mode === "development" ? "inline-cheap-source-map" : undefined,
     context: remixConfig.rootDirectory,
     target: "node",


### PR DESCRIPTION
Webpack was defaulting to production builds in development because `mode` wasn't passed.